### PR TITLE
update PATCH request to reprovision

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.1.0)
+    scim_rails (0.1.1)
       rails (~> 5.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ We would like to implement PATCH to be fully SCIM compliant in future releases.
 Sample request:
 
 ```bash
-$ curl -X PATCH 'http://username:password@localhost:3000/scim/v2/Users/1'
+$ curl -X PATCH 'http://username:password@localhost:3000/scim_rails/scim/v2/Users/1' -d '{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "replace", "value": { "active": false }}]}' -H 'Content-Type: application/scim+json'
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ NOTE: This Gem is not yet fully SCIM complaint. It was developed with the main f
 
 #### What is SCIM?
 
-SCIM stands for System for Cross-domain Identity Management. At its core, it is a set of rules defining how apps should interact for the purpose of creating, updating, and deprovisioning users. SCIM requests and responses can be sent in XML or JSON and this Gem uses JSON for ease of readabilty. 
+SCIM stands for System for Cross-domain Identity Management. At its core, it is a set of rules defining how apps should interact for the purpose of creating, updating, and deprovisioning users. SCIM requests and responses can be sent in XML or JSON and this Gem uses JSON for ease of readability. 
 
 To learn more about SCIM 2.0 you can read the documentation at [RFC 7643](https://tools.ietf.org/html/rfc7643) and [RFC 7644](https://tools.ietf.org/html/rfc7644).
 
@@ -92,7 +92,7 @@ $ curl -X GET 'http://username:password@localhost:3000/scim/v2/Users'
 
 This Gem provides two pagination filters; `startIndex` and `count`.
 
-`startIndex` is the positional number you would like to start at. This parameter can accept any integer but anything less than 1 will be interpreted as 1. If you visualize an array with all your user records in the array, `startIndex` is basically what element you would like to start at. If you are familiar with SQL this parameter is directly correlated to the query offset. **The default value for this fitler is 1.**
+`startIndex` is the positional number you would like to start at. This parameter can accept any integer but anything less than 1 will be interpreted as 1. If you visualize an array with all your user records in the array, `startIndex` is basically what element you would like to start at. If you are familiar with SQL this parameter is directly correlated to the query offset. **The default value for this filter is 1.**
 
 `count` is the number of records you would like present in the response. **The default value for this filter is 100.**
 
@@ -108,7 +108,7 @@ The pagination filters may be used on their own or in addition to the query filt
 
 ##### Querying
 
-Currently the only filter supported is a single level `eq`. More operators can be added failry easily in future releases. The SCIM RFC documents nested querying which is something we would like to implement in the future.
+Currently the only filter supported is a single level `eq`. More operators can be added fairly easily in future releases. The SCIM RFC documents nested querying which is something we would like to implement in the future.
 
 **Queryable attributes can be mapped in the configuration file.**
 
@@ -121,7 +121,7 @@ filter=formattedName eq Test User
 filter=id eq 1
 ```
 
-Unsuppored filter:
+Unsupported filter:
 
 ```
 filter=(email eq test@example.com) or (userName eq test@example.com)
@@ -185,14 +185,14 @@ $ curl -X PUT 'http://username:password@localhost:3000/scim/v2/Users/1' -d '{"sc
 
 ### Deprovision / Reprovision
 
-The PATCH request was implemented to work with Okta. Okta updates profiles with PUT and deprovisions / reprovisions with PATCH. This implemention of PATCH is not SCIM compliant as it does not update a single attribute on the user profile but instead only sends a status update request to the record.
+The PATCH request was implemented to work with Okta. Okta updates profiles with PUT and deprovisions / reprovisions with PATCH. This implementation of PATCH is not SCIM compliant as it does not update a single attribute on the user profile but instead only sends a status update request to the record.
 
 We would like to implement PATCH to be fully SCIM compliant in future releases.
 
 Sample request:
 
 ```bash
-$ curl -X PATCH 'http://username:password@localhost:3000/scim_rails/scim/v2/Users/1' -d '{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "replace", "value": { "active": false }}]}' -H 'Content-Type: application/scim+json'
+$ curl -X PATCH 'http://username:password@localhost:3000/scim/v2/Users/1' -d '{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "replace", "value": { "active": false }}]}' -H 'Content-Type: application/scim+json'
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ Sample request:
 $ curl -X PUT 'http://username:password@localhost:3000/scim/v2/Users/1' -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"test@example.com","name":{"givenName":"Test","familyName":"User"},"emails":[{"primary":true,"value":"test@example.com","type":"work"}],"displayName":"Test User","active":true}' -H 'Content-Type: application/scim+json'
 ```
 
-### Deprovision
+### Deprovision / Reprovision
 
-The PATCH request was implemented to work with Okta. Okta updates profiles with PUT and deprovisions with PATCH. This implemention of PATCH is not SCIM compliant as it does not update a single attribute on the user profile but instead only sends a deprovision request.
+The PATCH request was implemented to work with Okta. Okta updates profiles with PUT and deprovisions / reprovisions with PATCH. This implemention of PATCH is not SCIM compliant as it does not update a single attribute on the user profile but instead only sends a status update request to the record.
 
 We would like to implement PATCH to be fully SCIM compliant in future releases.
 

--- a/app/controllers/concerns/scim_rails/exception_handler.rb
+++ b/app/controllers/concerns/scim_rails/exception_handler.rb
@@ -8,6 +8,9 @@ module ScimRails
     class InvalidQuery < StandardError
     end
 
+    class UnsupportedPatchRequest < StandardError
+    end
+
     included do
       rescue_from ScimRails::ExceptionHandler::InvalidCredentials do
         json_response(
@@ -29,6 +32,17 @@ module ScimRails
             status: "400"
           },
           :bad_request
+        )
+      end
+
+      rescue_from ScimRails::ExceptionHandler::UnsupportedPatchRequest do
+        json_response(
+          {
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            detail: "Invalid PATCH request. This PATCH endpoint only supports deprovisioning and reprovisioning records.",
+            status: "422"
+          },
+          :unprocessable_entity
         )
       end
 

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,3 +1,3 @@
 module ScimRails
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
## Why?

The main purpose of this Gem right now is for us to be able to integrate seamlessly with Okta over SCIM. During testing we found that Okta sends reprovision requests using the PATCH endpoint as well as deprovision requests. Because we built it to only deprovision, we need to add that functionality.

## What?

What this PR adds is a check for the status during a PATCH request to pass that status along to the user record.

## Caveats

This implementation of the PATCH endpoint is not SCIM compliant. Bringing the endpoint to compliance is beyond the scope of this PR.

## Testing Notes

- [ ] Set up gem following directions in the [contributing section of the readme](https://github.com/lessonly/scim_rails/blob/master/README.md)
- [ ] Successfully deprovision a user
- [ ] Successfully reprovision a user