### PR TITLE
fix error rescuing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.1.1)
+    scim_rails (0.1.2)
       rails (~> 5.0.0)
 
 GEM

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,3 +1,3 @@
 module ScimRails
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
## Why?

I made an incorrect assumption about how rescue statements work! I thought by putting the catch-all rescue statement last that it would exercise only after the other rescue statements have been evaluated. This was exactly wrong. The catch-all rescue statement needed to be first because rescue statements after it are evaluated before it. [Documentation here.](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from)

## What?

This PR iterates the patch level version and changes the order of the rescue statements.

## Testing Notes

The only way to really test this is to remove the logic that the code only execute in production and run the specs to see that they still pass.

```ruby
app/controllers/concerns/scim_rails/exception_handler.rb:19

if Rails.env.production?
  rescue_from StandardError do
    json_response(
      {
        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
        status: "500"
      },
      :internal_server_error
    )
  end
end
```

- [ ] Change the code above from `if` to `unless`
- [ ] Run specs
- [ ] Specs pass!
