### PR TITLE
fix PUT deprovisioning bug

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -98,7 +98,9 @@ module ScimRails
     end
 
     def active?
-      active = put_active_param || patch_active_param
+      active = put_active_param
+      active = patch_active_param if active.nil?
+
       case active
       when true, "true", 1
         true

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -419,6 +419,27 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         expect(response.status).to eq 200
       end
 
+      it "archives an inactive record" do
+        request.content_type = "application/scim+json"
+        put :put_update, params: {
+          id: 1,
+          userName: "test@example.com",
+          name: {
+            givenName: "Test",
+            familyName: "User"
+          },
+          emails: [
+            {
+              value: "test@example.com"
+            },
+          ],
+          active: false
+        }
+
+        expect(response.status).to eq 200
+        expect(user.reload.active?).to eq false
+      end
+
       it "returns :not_found for id that cannot be found" do
         get :put_update, params: { id: "fake_id" }
 


### PR DESCRIPTION
## Why?

When trying to fix PATCH reprovisioning I broke PUT deprovisioning!

## What?

This PR fixes the logic surrounding `params["active"]` and adds a spec to ensure that PUT does indeed deprovision. 

## Testing Notes

- [ ] Successfully send a PUT request to deprovision a user
- [ ] Successfully send a PUT request to reprovision a user
- [ ] Successfully send a PATCH request to deprovision a user
- [ ] Successfully send a PUT request to reprovision a user