### PR TITLE
Allow the create endpoint to find and update users

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.1.3)
+    scim_rails (0.1.4)
       rails (~> 5.0.0)
 
 GEM
@@ -56,7 +56,7 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.2.0)
       concurrent-ruby (~> 1.0)

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -27,7 +27,13 @@ module ScimRails
     end
 
     def create
-      user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_user_params)
+      username_key = ScimRails.config.queryable_user_attributes[:userName]
+      username_create_hash = Hash.new
+      username_create_hash[username_key] = permitted_user_params[username_key]
+      user = @company
+        .public_send(ScimRails.config.scim_users_scope)
+        .find_or_create_by(username_create_hash)
+      user.update!(permitted_user_params)
       update_status(user) unless put_active_param.nil?
       json_scim_response(object: user, status: :created)
     end

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -28,11 +28,11 @@ module ScimRails
 
     def create
       username_key = ScimRails.config.queryable_user_attributes[:userName]
-      username_create_hash = Hash.new
-      username_create_hash[username_key] = permitted_user_params[username_key]
+      find_by_username = Hash.new
+      find_by_username[username_key] = permitted_user_params[username_key]
       user = @company
         .public_send(ScimRails.config.scim_users_scope)
-        .find_or_create_by(username_create_hash)
+        .find_or_create_by(find_by_username)
       user.update!(permitted_user_params)
       update_status(user) unless put_active_param.nil?
       json_scim_response(object: user, status: :created)

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,3 +1,3 @@
 module ScimRails
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -305,12 +305,12 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         expect(company.users.count).to eq 0
       end
 
-      it "returns 201 if user already exists" do
+      it "returns 201 if user already exists and updates user" do
         create(:user, email: "new@example.com", company: company)
 
         post :create, params: {
           name: {
-            givenName: "New",
+            givenName: "Not New",
             familyName: "User"
           },
           emails: [
@@ -322,6 +322,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
         expect(response.status).to eq 201
         expect(company.users.count).to eq 1
+        expect(company.users.first.first_name).to eq "Not New"
       end
 
       it "creates and archives inactive user" do

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     context "when unauthorized" do
       it "returns scim+json content type" do
         get :index
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 
@@ -37,7 +37,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
       it "returns scim+json content type" do
         get :index
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 
@@ -146,7 +146,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     context "when unauthorized" do
       it "returns scim+json content type" do
         get :show, params: { id: 1 }
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 
@@ -172,7 +172,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
       it "returns scim+json content type" do
         get :show, params: { id: 1 }
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 
@@ -207,7 +207,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     context "when unauthorized" do
       it "returns scim+json content type" do
         post :create
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 
@@ -305,7 +305,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         expect(company.users.count).to eq 0
       end
 
-      it "returns 409 if user already exists" do
+      it "returns 201 if user already exists" do
         create(:user, email: "new@example.com", company: company)
 
         post :create, params: {
@@ -320,7 +320,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
           ]
         }
 
-        expect(response.status).to eq 409
+        expect(response.status).to eq 201
         expect(company.users.count).to eq 1
       end
 
@@ -355,7 +355,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     context "when unauthorized" do
       it "returns scim+json content type" do
         put :put_update, params: { id: 1 }
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 
@@ -383,7 +383,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
       it "returns scim+json content type" do
         put :put_update, params: put_params
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 
@@ -450,7 +450,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     context "when unauthorized" do
       it "returns scim+json content type" do
         patch :patch_update, params: patch_params(id: 1)
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 
@@ -478,7 +478,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
       it "returns scim+json content type" do
         patch :patch_update, params: patch_params(id: 1)
-  
+
         expect(response.content_type).to eq "application/scim+json, application/json"
       end
 


### PR DESCRIPTION
## Why?

OKTA is expecting users from group assignments to be synced if they are already in Lessonly. The problem is their group endpoint uses POST for each user in the group which is the create endpoint and we were blocking that if a user was already in the system

## What?

This allows a POST create action to find and update a user if they already exist by whatever is configured as the username

## Caveats

There was a spec built to cover this exact scenario so it's possible they had this as something in their documentation, however, they are denying our approval because of this blocked action.

There was a second issue with group assignment attributes but I was unable to reproduce. I'm going to reach out to our advocate in OKTA and ask for more clarity 

## Testing Notes

Not much to test directly from the gem. Verify the specs are doing what we want and that they are passing. We will do full integration test when we update the gem in the core app

