### PR TITLE
Prevent create endpoint from updating existing users (optional)

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -27,7 +27,9 @@ module ScimRails
     end
 
     def create
-      unless ScimRails.config.scim_user_prevent_update_on_create
+      if ScimRails.config.scim_user_prevent_update_on_create
+        user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_user_params)
+      else
         username_key = ScimRails.config.queryable_user_attributes[:userName]
         find_by_username = Hash.new
         find_by_username[username_key] = permitted_user_params[username_key]
@@ -35,8 +37,6 @@ module ScimRails
           .public_send(ScimRails.config.scim_users_scope)
           .find_or_create_by(find_by_username)
         user.update!(permitted_user_params)
-      else
-        user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_user_params)
       end
       update_status(user) unless put_active_param.nil?
       json_scim_response(object: user, status: :created)

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -27,13 +27,17 @@ module ScimRails
     end
 
     def create
-      username_key = ScimRails.config.queryable_user_attributes[:userName]
-      find_by_username = Hash.new
-      find_by_username[username_key] = permitted_user_params[username_key]
-      user = @company
-        .public_send(ScimRails.config.scim_users_scope)
-        .find_or_create_by(find_by_username)
-      user.update!(permitted_user_params)
+      unless ScimRails.config.scim_user_prevent_update_on_create
+        username_key = ScimRails.config.queryable_user_attributes[:userName]
+        find_by_username = Hash.new
+        find_by_username[username_key] = permitted_user_params[username_key]
+        user = @company
+          .public_send(ScimRails.config.scim_users_scope)
+          .find_or_create_by(find_by_username)
+        user.update!(permitted_user_params)
+      else
+        user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_user_params)
+      end
       update_status(user) unless put_active_param.nil?
       json_scim_response(object: user, status: :created)
     end

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -18,6 +18,10 @@ ScimRails.configure do |config|
   # authenticatable model.
   config.scim_users_scope = :users
 
+  # Determine whether the create endpoint updates users that alread exist
+  # or throws an error (returning 409 Conflict in accordance with SCIM spec)
+  config.scim_user_prevent_update_on_create = :false
+
   # Default sort order for pagination is by id. If you
   # use non sequential ids for user records, uncomment
   # the below line and configure a determinate order.
@@ -33,7 +37,7 @@ ScimRails.configure do |config|
   # Hash of queryable attribtues on the user model. If
   # the attribute is not listed in this hash it cannot
   # be queried by this Gem. The structure of this hash
-  # is { queryable_scim_attribute => user_attribute }. 
+  # is { queryable_scim_attribute => user_attribute }.
   config.queryable_user_attributes = {
     userName: :email,
     givenName: :first_name,
@@ -54,7 +58,7 @@ ScimRails.configure do |config|
   # for this Gem to figure out where to look in a SCIM
   # response for mutable values. This object should
   # include all attributes listed in
-  # config.mutable_user_attributes. 
+  # config.mutable_user_attributes.
   config.mutable_user_attributes_schema = {
     name: {
       givenName: :first_name,

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -20,7 +20,7 @@ ScimRails.configure do |config|
 
   # Determine whether the create endpoint updates users that already exist
   # or throws an error (returning 409 Conflict in accordance with SCIM spec)
-  config.scim_user_prevent_update_on_create = :false
+  config.scim_user_prevent_update_on_create = false
 
   # Default sort order for pagination is by id. If you
   # use non sequential ids for user records, uncomment

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -18,7 +18,7 @@ ScimRails.configure do |config|
   # authenticatable model.
   config.scim_users_scope = :users
 
-  # Determine whether the create endpoint updates users that alread exist
+  # Determine whether the create endpoint updates users that already exist
   # or throws an error (returning 409 Conflict in accordance with SCIM spec)
   config.scim_user_prevent_update_on_create = :false
 

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -20,11 +20,12 @@ module ScimRails
       :scim_users_list_order,
       :scim_users_model,
       :scim_users_scope,
+      :scim_user_prevent_update_on_create,
       :user_attributes,
       :user_deprovision_method,
       :user_reprovision_method,
       :user_schema
-      
+
     def initialize
       @basic_auth_model = "Company"
       @scim_users_list_order = :id

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -325,6 +325,26 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         expect(company.users.first.first_name).to eq "Not New"
       end
 
+      it "returns 409 if user already exists and config.scim_user_prevent_update_on_create is set to true" do
+        allow(ScimRails.config).to receive(:scim_user_prevent_update_on_create).and_return(true)
+        create(:user, email: "new@example.com", company: company)
+
+        post :create, params: {
+          name: {
+            givenName: "Not New",
+            familyName: "User"
+          },
+          emails: [
+            {
+              value: "new@example.com"
+            }
+          ]
+        }
+
+        expect(response.status).to eq 409
+        expect(company.users.count).to eq 1
+      end
+
       it "creates and archives inactive user" do
         post :create, params: {
           id: 1,


### PR DESCRIPTION
## Why?

The SCIM spec requires the create endpoint to return a 409 response if a resource already exists. OKTA requires this behavior for any SCIM integrations; this is also what their [RunScope Test Suite](https://www.okta.com/integrate/documentation/scim/#step-2-test-your-scim-server) expects.

## What?

Add a configuration option to disable the "update-on-create" functionality implemented by https://github.com/lessonly/scim_rails/pull/5

## Caveats

This change is no impact on existing implementations as the out-of-the box behavior remains the same. It will bring scim_rails closer to the SCIM spec.

## Testing Notes

Spec coverage has been updated to test this case.

## Further Reading

https://tools.ietf.org/html/rfc7644#section-3.3
