### PR TITLE
Add support for OAuth Bearer Authentication

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.2.2)
+    scim_rails (0.3.0)
       jwt (~> 2.2)
       rails (>= 5.0, < 6.1)
 
@@ -144,7 +144,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.2.1)
+    scim_rails (0.2.2)
+      jwt (~> 2.2)
       rails (>= 5.0, < 6.1)
 
 GEM
@@ -77,6 +78,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jwt (2.2.1)
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -142,7 +144,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -175,4 +177,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ All responses will be sent with a `Content-Type` of `application/scim+json`.
 This gem supports both basic and OAuth bearer authentication.
 
 ##### Basic Auth
+###### Username
+The config setting `basic_auth_model_searchable_attribute` is the model attribute used to authenticate as the `username`. It defaults to `:subdomain`.
+
+Ensure it is unique to the model records.
+
+###### Password
+The config setting `basic_auth_model_authenticatable_attribute` is the model attribute used to authenticate as `password`. Defaults to `:api_token`.
+
+Assuming your model is `Company` and attribute is `:api_token`, you can generate the token using:
+```ruby
+company.api_token = ScimRails::Encoder.encode(company)
+# don't forget to persist the record
+```
+
+###### Sample Request
 
 ```bash
 $ curl -X GET 'http://username:password@localhost:3000/scim/v2/Users'
@@ -90,10 +105,22 @@ $ curl -X GET 'http://username:password@localhost:3000/scim/v2/Users'
 
 ##### OAuth Bearer
 
+###### Signing Algorithm
+In the config settings, ensure you set `signing_algorithm` to a valid JWT signing algorithm, e.g "HS256". Defaults to `"none"` when not set.
+
+###### Signing Secret
+In the config settings, ensure you set `signing_secret` to a valid token generated using this gem. Defaults to `nil` when not set.
+
+Generating a signing secret:
+```ruby
+ScimRails::Encoder.encode(company)
+```
+
+##### Sample Request
+
 ```bash
 $ curl -H 'Authorization: Bearer xxxxxxx.xxxxxx' -X GET 'http://localhost:3000/scim/v2/Users'
 ```
-
 
 ### List
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,15 @@ Ensure it is unique to the model records.
 ###### Password
 The config setting `basic_auth_model_authenticatable_attribute` is the model attribute used to authenticate as `password`. Defaults to `:api_token`.
 
-Assuming your model is `Company` and attribute is `:api_token`, you can generate the token using:
+Assuming the attribute is `:api_token`, generate the password using:
 ```ruby
-company.api_token = ScimRails::Encoder.encode(company)
-# don't forget to persist the record
+token = ScimRails::Encoder.encode(company)
+# use the token as password for requests
+company.api_token = token # required
+company.save! # don't forget to persist the company record
 ```
+
+This is necessary irrespective of your authentication choice(s) - basic auth, oauth bearer or both.
 
 ###### Sample Request
 
@@ -109,11 +113,14 @@ $ curl -X GET 'http://username:password@localhost:3000/scim/v2/Users'
 In the config settings, ensure you set `signing_algorithm` to a valid JWT signing algorithm, e.g "HS256". Defaults to `"none"` when not set.
 
 ###### Signing Secret
-In the config settings, ensure you set `signing_secret` to a valid token generated using this gem. Defaults to `nil` when not set.
+In the config settings, ensure you set `signing_secret` to a secret key that will be used to encode and decode tokens. Defaults to `nil` when not set.
 
-Generating a signing secret:
+If you have already generated the `api_token` in the "Basic Auth" section, then use that as your bearer token and ignore the steps below:
 ```ruby
-ScimRails::Encoder.encode(company)
+token = ScimRails::Encoder.encode(company)
+# use the token as bearer token for requests
+company.api_token = token #required
+company.save! # don't forget to persist the company record
 ```
 
 ##### Sample Request

--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ When sending requests to the server the `Content-Type` should be set to `applica
 
 All responses will be sent with a `Content-Type` of `application/scim+json`.
 
+#### Authentication
+
+This gem supports both basic and OAuth bearer authentication.
+
+##### Basic Auth
+
+```bash
+$ curl -X GET 'http://username:password@localhost:3000/scim/v2/Users'
+```
+
+##### OAuth Bearer
+
+```bash
+$ curl -H 'Authorization: Bearer xxxxxxx.xxxxxx' -X GET 'http://localhost:3000/scim/v2/Users'
+```
+
+
 ### List
 
 ##### All

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -9,14 +9,30 @@ module ScimRails
     private
 
     def authorize_request
-      authenticate_with_http_basic do |username, password|
+      send(authentication_strategy) do |username, password|
         authorization = AuthorizeApiRequest.new(
           searchable_attribute: username,
           authentication_attribute: password
         )
         @company = authorization.company
       end
-      raise  ScimRails::ExceptionHandler::InvalidCredentials if @company.blank?
+      raise ScimRails::ExceptionHandler::InvalidCredentials if @company.blank?
+    end
+
+    def authentication_strategy
+      if request.headers["Authorization"]&.include?("Bearer")
+        :authenticate_with_oauth_bearer
+      else
+        :authenticate_with_http_basic
+      end
+    end
+
+    def authenticate_with_oauth_bearer
+      token = request.headers["Authorization"].split(" ").last
+      payload = ScimRails::Encoder.decode(token).with_indifferent_access
+      searchable_attribute = payload[ScimRails.config.basic_auth_model_searchable_attribute]
+
+      yield searchable_attribute, token
     end
   end
 end

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -9,10 +9,10 @@ module ScimRails
     private
 
     def authorize_request
-      send(authentication_strategy) do |username, password|
+      send(authentication_strategy) do |searchable_attribute, authentication_attribute|
         authorization = AuthorizeApiRequest.new(
-          searchable_attribute: username,
-          authentication_attribute: password
+          searchable_attribute: searchable_attribute,
+          authentication_attribute: authentication_attribute
         )
         @company = authorization.company
       end
@@ -28,11 +28,11 @@ module ScimRails
     end
 
     def authenticate_with_oauth_bearer
-      token = request.headers["Authorization"].split(" ").last
-      payload = ScimRails::Encoder.decode(token).with_indifferent_access
+      authentication_attribute = request.headers["Authorization"].split(" ").last
+      payload = ScimRails::Encoder.decode(authentication_attribute).with_indifferent_access
       searchable_attribute = payload[ScimRails.config.basic_auth_model_searchable_attribute]
 
-      yield searchable_attribute, token
+      yield searchable_attribute, authentication_attribute
     end
   end
 end

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -22,14 +22,16 @@ ScimRails.configure do |config|
   # or throws an error (returning 409 Conflict in accordance with SCIM spec)
   config.scim_user_prevent_update_on_create = false
 
-  # Cryptographic algorithm used for signing the auth token.
+  # Cryptographic algorithm used for signing the auth tokens.
   # It supports all algorithms supported by the jwt gem.
   # See https://github.com/jwt/ruby-jwt#algorithms-and-usage for supported algorithms
   # It is "none" by default, hence generated tokens are unsigned
+  # The tokens do not need to be signed if you only need basic authentication.
   # config.signing_algorithm = "HS256"
 
   # Secret token used to sign authorization tokens
   # It is `nil` by default, hence generated tokens are unsigned
+  # The tokens do not need to be signed if you only need basic authentication.
   # config.signing_secret = SECRET_TOKEN
 
   # Default sort order for pagination is by id. If you

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -22,6 +22,16 @@ ScimRails.configure do |config|
   # or throws an error (returning 409 Conflict in accordance with SCIM spec)
   config.scim_user_prevent_update_on_create = false
 
+  # Cryptographic algorithm used for signing the auth token.
+  # It supports all algorithms supported by the jwt gem.
+  # See https://github.com/jwt/ruby-jwt#algorithms-and-usage for supported algorithms
+  # It is "none" by default, hence generated tokens are unsigned
+  # config.signing_algorithm = "HS256"
+
+  # Secret token used to sign authorization tokens
+  # It is `nil` by default, hence generated tokens are unsigned
+  # config.signing_secret = SECRET_TOKEN
+
   # Default sort order for pagination is by id. If you
   # use non sequential ids for user records, uncomment
   # the below line and configure a determinate order.

--- a/lib/scim_rails.rb
+++ b/lib/scim_rails.rb
@@ -1,5 +1,6 @@
 require "scim_rails/engine"
 require "scim_rails/config"
+require "scim_rails/encoder"
 
 module ScimRails
 end

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -10,6 +10,8 @@ module ScimRails
   end
 
   class Config
+    ALGO_NONE = "none".freeze
+
     attr_accessor \
       :basic_auth_model,
       :basic_auth_model_authenticatable_attribute,
@@ -21,6 +23,8 @@ module ScimRails
       :scim_users_model,
       :scim_users_scope,
       :scim_user_prevent_update_on_create,
+      :signing_secret,
+      :signing_algorithm,
       :user_attributes,
       :user_deprovision_method,
       :user_reprovision_method,
@@ -30,6 +34,7 @@ module ScimRails
       @basic_auth_model = "Company"
       @scim_users_list_order = :id
       @scim_users_model = "User"
+      @signing_algorithm = ALGO_NONE
       @user_schema = {}
       @user_attributes = []
     end

--- a/lib/scim_rails/encoder.rb
+++ b/lib/scim_rails/encoder.rb
@@ -1,0 +1,25 @@
+require "jwt"
+
+module ScimRails
+  module Encoder
+    extend self
+
+    def encode(company)
+      payload = {
+        iat: Time.current.to_i,
+        ScimRails.config.basic_auth_model_searchable_attribute =>
+          company.public_send(ScimRails.config.basic_auth_model_searchable_attribute)
+      }
+
+      JWT.encode(payload, ScimRails.config.signing_secret, ScimRails.config.signing_algorithm)
+    end
+
+    def decode(token)
+      verify = ScimRails.config.signing_algorithm != ScimRails::Config::ALGO_NONE
+
+      JWT.decode(token, ScimRails.config.signing_secret, verify, algorithm: ScimRails.config.signing_algorithm).first
+    rescue JWT::VerificationError, JWT::DecodeError
+      raise ScimRails::ExceptionHandler::InvalidCredentials
+    end
+  end
+end

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,3 +1,3 @@
 module ScimRails
-  VERSION = '0.2.2'
+  VERSION = '0.3.0'
 end

--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "~> 2.4"
   s.add_dependency "rails", ">= 5.0", "< 6.1"
-  s.add_runtime_dependency "jwt", "~> 2.2"
+  s.add_runtime_dependency "jwt", "~> 1.5.1"
   s.test_files = Dir["spec/**/*"]
 
   s.add_development_dependency "bundler", "~> 2.0"

--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "~> 2.4"
   s.add_dependency "rails", ">= 5.0", "< 6.1"
+  s.add_runtime_dependency "jwt", "~> 2.2"
   s.test_files = Dir["spec/**/*"]
 
   s.add_development_dependency "bundler", "~> 2.0"

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
   let(:credentials) { Base64::encode64("#{company.subdomain}:#{company.api_token}") }
   let(:authorization) { "Basic #{credentials}" }
 
-  def post_request(content_type)
+  def post_request(content_type = "application/scim+json")
     # params need to be transformed into a string to test if they are being parsed by Rack
 
     post "/scim_rails/scim/v2/Users",
@@ -46,6 +46,28 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
       expect(request.params).not_to include :name
       expect(response.status).to eq 422
       expect(company.users.count).to eq 0
+    end
+  end
+
+  context "OAuth Bearer Authorization" do
+    context "with valid token" do
+      let(:authorization) { "Bearer #{company.api_token}" }
+
+      it "supports OAuth bearer authorization and succeeds" do
+        expect { post_request }.to change(company.users, :count).from(0).to(1)
+
+        expect(response.status).to eq 201
+      end
+    end
+
+    context "with invalid token" do
+      let(:authorization) { "Bearer #{SecureRandom.hex}" }
+
+      it "The request fails" do
+        expect { post_request }.not_to change(company.users, :count)
+
+        expect(response.status).to eq 401
+      end
     end
   end
 end

--- a/spec/dummy/config/initializers/scim_rails_config.rb
+++ b/spec/dummy/config/initializers/scim_rails_config.rb
@@ -7,6 +7,9 @@ ScimRails.configure do |config|
   config.scim_users_scope = :users
   config.scim_users_list_order = :id
 
+  config.signing_algorithm = "HS256"
+  config.signing_secret = "2d6806dd11c2fece2e81b8ca76dcb0062f5b08e28e3264e8ba1c44bbd3578b70"
+
   config.user_deprovision_method = :archive!
   config.user_reprovision_method = :unarchive!
 

--- a/spec/factories/company.rb
+++ b/spec/factories/company.rb
@@ -2,6 +2,9 @@ FactoryBot.define do
   factory :company do
     name { "Test Company" }
     subdomain { "test" }
-    api_token { "1" }
+
+    after(:build) do |company|
+      company.api_token = ScimRails::Encoder.encode(company)
+    end
   end
 end

--- a/spec/lib/scim_rails/encoder_spec.rb
+++ b/spec/lib/scim_rails/encoder_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+
+describe ScimRails::Encoder do
+  let(:company) { Company.new(subdomain: "test") }
+
+  describe "::encode" do
+    context "with signing configuration" do
+      it "generates a signed token with the company attribute" do
+        token   = ScimRails::Encoder.encode(company)
+        payload = ScimRails::Encoder.decode(token)
+
+        expect(token).to match /[a-z|A-Z|0-9.]{16,}\.[a-z|A-Z|0-9.]{16,}/
+        expect(payload).to contain_exactly(["iat", Integer], ["subdomain", "test"])
+      end
+    end
+
+    context "without signing configuration" do
+      before do
+        allow(ScimRails.config).to receive(:signing_secret).and_return(nil)
+        allow(ScimRails.config).to receive(:signing_algorithm).and_return(ScimRails::Config::ALGO_NONE)
+      end
+
+      it "generates an unsigned token with the company attribute" do
+        token   = ScimRails::Encoder.encode(company)
+        payload = ScimRails::Encoder.decode(token)
+
+        expect(token).to match /[a-z|A-Z|0-9.]{16,}/
+        expect(payload).to contain_exactly(["iat", Integer], ["subdomain", "test"])
+      end
+    end
+  end
+
+  describe "::decode" do
+    let(:token) { ScimRails::Encoder.encode(company) }
+
+    it "raises InvalidCredentials error for an invalid token" do
+      token = "f487bf84bfub4f74fj4894fnh483f4h4u8f"
+      expect { ScimRails::Encoder.decode(token) }.to raise_error ScimRails::ExceptionHandler::InvalidCredentials
+    end
+
+    context "with signing configuration" do
+      it "decodes a signed token, returning the company attributes" do
+        payload = ScimRails::Encoder.decode(token)
+
+        expect(payload).to contain_exactly(["iat", Integer], ["subdomain", "test"])
+      end
+    end
+
+    context "without signing configuration" do
+      before do
+        allow(ScimRails.config).to receive(:signing_secret).and_return(nil)
+        allow(ScimRails.config).to receive(:signing_algorithm).and_return(ScimRails::Config::ALGO_NONE)
+      end
+
+      it "decodes an unsigned token, returning the company attributes" do
+        payload = ScimRails::Encoder.decode(token)
+
+        expect(payload).to contain_exactly(["iat", Integer], ["subdomain", "test"])
+      end
+    end
+  end
+end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -10,6 +10,9 @@ ScimRails.configure do |config|
   config.scim_users_scope = :users
   config.scim_users_list_order = :id
 
+  config.signing_algorithm = "HS256"
+  config.signing_secret = "2d6806dd11c2fece2e81b8ca76dcb0062f5b08e28e3264e8ba1c44bbd3578b70"
+
   config.user_deprovision_method = :archive!
   config.user_reprovision_method = :unarchive!
 


### PR DESCRIPTION
## Why?
[[ch35118](https://app.clubhouse.io/lessonly/story/35118/add-bearer-token-auth-to-scim-rails-gem)]

OAuth bearer authentication support is needed by some providers

## What?

- Add configuration for signing generated auth token. Tokens are unsigned by default.
  The same key and algorithm should be used encode and decode the tokens.
  - `ScimRails.config.signing_secret` `nil` by default
  - `ScimRails.config.signing_algorithm` `"none"` by default

- Add helper methods to encode and decode the bearer token. It is expected that the token is encoded with the company searchable attribute (e.g `subdomain`).
  
  ```ruby
  ScimRails::Encoder.encode(company)
  # => "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1NzI0ODQyMzIsInN1YmRvbWFpbiI6InRlc3RfY29tcGFueSJ9.fO0Yc_5EpPthbLUl0FbhzV5zMg2mj0e-8CdsKr3p7x"

  ScimRails::Encoder.decode(token)
  # => {"iat"=>1572484232, "subdomain"=>"test_company"}
  ```

- Add support for OAuth Bearer Authentication. HTTP basic is used without a bearer token
  ```bash
  $ curl -H 'Authorization: Bearer xxxxxxx.xxxxxx' -X GET 'http://localhost:3000/scim/v2/Users'
  ```


## Testing Notes

Generate a token using the helper method. `ScimRails::Encoder.encode(company)`

A list of things to test:

- [ ] Set up the dummy app locally and make requests using a bearer token.
