### PR TITLE
fix DEPRECATION WARNING for specs.

### DIFF
--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         get :index
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "fails with no credentials" do
@@ -38,7 +38,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         get :index
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "is successful with valid credentials" do
@@ -147,7 +147,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         get :show, params: { id: 1 }
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "fails with no credentials" do
@@ -173,7 +173,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         get :show, params: { id: 1 }
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "is successful with valid credentials" do
@@ -208,7 +208,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         post :create
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "fails with no credentials" do
@@ -244,7 +244,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
           ]
         }
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "is successful with valid credentials" do
@@ -377,7 +377,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         put :put_update, params: { id: 1 }
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "fails with no credentials" do
@@ -405,7 +405,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         put :put_update, params: put_params
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "is successful with with valid credentials" do
@@ -472,7 +472,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         patch :patch_update, params: patch_params(id: 1)
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "fails with no credentials" do
@@ -500,7 +500,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "returns scim+json content type" do
         patch :patch_update, params: patch_params(id: 1)
 
-        expect(response.content_type).to eq "application/scim+json"
+        expect(response.media_type).to eq "application/scim+json"
       end
 
       it "is successful with valid credentials" do

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
 
       expect(request.params).to include :name
       expect(response.status).to eq 201
-      expect(response.content_type).to eq "application/scim+json"
+      expect(response.media_type).to eq "application/scim+json"
       expect(company.users.count).to eq 1
     end
 


### PR DESCRIPTION
## Why?
- resolved issue #13 Rails 6.1 DEPRECATION WARNING for specs.
- https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-response-content-type-now-returned-content-type-header-as-it-is

## What?
response content_type check want just MIME type.

## Caveats

none

## Testing Notes

none


## Alternatives Considered

none

## Further Reading

- https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-response-content-type-now-returned-content-type-header-as-it-is

## Merge Instructions

Please **DO NOT** squash my commits when merging
