### PR TITLE
Add logging for unhandled exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/dummy/db/*.sqlite3
 spec/dummy/db/*.sqlite3-journal
 spec/dummy/log/*.log
 spec/dummy/tmp/
+.rubocop-https*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_from:
+  - https://raw.githubusercontent.com/lessonly/rubocop-default-configuration/master/.rubocop.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Upcoming Release
+
+- Any unhandled error is now logged to the configured rails logger by default. You can also now supply a custom callable that will be used to handle those exceptions instead.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,20 @@ Sample request:
 $ curl -X PATCH 'http://username:password@localhost:3000/scim/v2/Users/1' -d '{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "replace", "value": { "active": false }}]}' -H 'Content-Type: application/scim+json'
 ```
 
+### Error Handling
+
+By default, scim_rails will output any unhandled exceptions to your configured rails logs.
+
+If you would like, you can supply a custom handler for exceptions in the initializer. The only requirement is that the value you supply responds to `#call`.
+
+For example, you might want to notify Honeybadger:
+
+```ruby
+ScimRails.configure do |config|
+  config.on_error = ->(e) { Honeybadger.notify(e) }
+end
+```
+
 ## Contributing
 
 ### [Code of Conduct](https://github.com/lessonly/scim_rails/blob/master/CODE_OF_CONDUCT.md)

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-APP_RAKEFILE = File.expand_path("../test/dummy/Rakefile", __FILE__)
+APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)
 load 'rails/tasks/engine.rake'
 
 

--- a/app/controllers/concerns/scim_rails/exception_handler.rb
+++ b/app/controllers/concerns/scim_rails/exception_handler.rb
@@ -12,12 +12,15 @@ module ScimRails
     end
 
     included do
-      # StandardError must be ordered _first_ or it will catch all exceptions
-      #
-      # TODO: Build a plugin/configuration for error handling so that the
-      # detailed production errors are logged somewhere if desired.
       if Rails.env.production?
-        rescue_from StandardError do
+        rescue_from StandardError do |exception|
+          on_error = ScimRails.config.on_error
+          if on_error.respond_to?(:call)
+            on_error.call(exception)
+          else
+            Rails.logger.error(exception.inspect)
+          end
+
           json_response(
             {
               schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],

--- a/bin/rails
+++ b/bin/rails
@@ -4,6 +4,7 @@
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/scim_rails/engine', __FILE__)
+APP_PATH = File.expand_path('../../spec/dummy/config/application', __FILE__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScimRails
   class << self
     def configure
@@ -5,22 +7,26 @@ module ScimRails
     end
 
     def config
-      @_config ||= Config.new
+      @config ||= Config.new
     end
   end
 
+  # Class containing configuration of ScimRails
   class Config
-    ALGO_NONE = "none".freeze
+    ALGO_NONE = "none"
+
+    attr_writer \
+      :basic_auth_model,
+      :mutable_user_attributes_schema,
+      :scim_users_model
 
     attr_accessor \
-      :basic_auth_model,
       :basic_auth_model_authenticatable_attribute,
       :basic_auth_model_searchable_attribute,
       :mutable_user_attributes,
-      :mutable_user_attributes_schema,
+      :on_error,
       :queryable_user_attributes,
       :scim_users_list_order,
-      :scim_users_model,
       :scim_users_scope,
       :scim_user_prevent_update_on_create,
       :signing_secret,


### PR DESCRIPTION
## Why?

resolves lessonly/scim_rails#23
fixes lessonly/scim_rails#25
fixes lessonly/scim_rails#26

The scim engine returns a custom response to the caller in the event
that there is a 500 error in the engine. It rescues any standard error
in order to do this.

Unfortunately this means that when something is broken it does not
bubble up to the parent app's error handling system or even be printed
in the logs.

We cannot just re-raise the exception because you cannot return a
response AND raise an exception as a part of the same request.

To help, this PR will make is possible for you to supply a callable
object that take the exception as it's argument.

If no callable object is provided, we will output the exception to the
logs so that silence is not the default.

To get the old behavior of completely ignoring an exception, you could
supply an empty proc.


This also fixes some pains encountered during development with running tasks and commands

## Testing Notes

This one is a bit complicated to test because the exception catching behavior is only configured to happen in production environments.

You can make sure that the existing spec pass, and to see the exception handling in action you can pull down the code and make the following modifications:

- In `app/controllers/concerns/scim_rails/exception_handler.rb` change `Rails.env.production?` to `true`
- Then, add a custom error handler to the dummy app's initializer: `config.on_error = ->(e) { puts "Found error #{e}" }`
- You can then open the users controller and add `raise "a fuss"` at the top of one of the actions.

Run the test suite now... you should see failures related to the response not matching and you should see the output from the puts.

## Merge Instructions

Please do a clear rebase of these commits when merging
