### PR TITLE
Fix exception raised when patch endpoint receives invalid request

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -126,9 +126,23 @@ module ScimRails
     end
 
     def patch_active_param
-      active = params.dig("Operations", 0, "value", "active")
-      raise ScimRails::ExceptionHandler::UnsupportedPatchRequest if active.nil?
-      active
+      handle_invalid = lambda do
+        raise ScimRails::ExceptionHandler::UnsupportedPatchRequest
+      end
+
+      operations = params["Operations"] || {}
+
+      valid_operation = operations.find(handle_invalid) do |operation|
+        valid_patch_operation?(operation)
+      end
+
+      valid_operation.dig("value", "active")
+    end
+
+    def valid_patch_operation?(operation)
+      operation["op"] == "replace" &&
+        operation["value"] &&
+        operation["value"]["active"]
     end
   end
 end

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -569,6 +569,53 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         response_body = JSON.parse(response.body)
         expect(response_body.dig("schemas", 0)).to eq "urn:ietf:params:scim:api:messages:2.0:Error"
       end
+
+      it "returns 422 when value is " do
+        patch :patch_update, params: {
+          id: 1,
+          Operations: [
+            {
+              op: "replace",
+              path: "displayName",
+              value: "Francis"
+            }
+          ]
+        }
+
+        expect(response.status).to eq 422
+        response_body = JSON.parse(response.body)
+        expect(response_body.dig("schemas", 0)).to eq "urn:ietf:params:scim:api:messages:2.0:Error"
+      end
+
+      it "returns 422 when value is missing" do
+        patch :patch_update, params: {
+          id: 1,
+          Operations: [
+            {
+              op: "replace"
+            }
+          ]
+        }
+
+        expect(response.status).to eq 422
+        response_body = JSON.parse(response.body)
+        expect(response_body.dig("schemas", 0)).to eq "urn:ietf:params:scim:api:messages:2.0:Error"
+      end
+
+      it "returns 422 operations key is missing" do
+        patch :patch_update, params: {
+          id: 1,
+          Foobars: [
+            {
+              op: "replace"
+            }
+          ]
+        }
+
+        expect(response.status).to eq 422
+        response_body = JSON.parse(response.body)
+        expect(response_body.dig("schemas", 0)).to eq "urn:ietf:params:scim:api:messages:2.0:Error"
+      end
     end
   end
 


### PR DESCRIPTION
Fixes lessonly/scim_rails#29

## Testing Notes

Is any special setup required to test this change? Non-obvious things that should be checked?

A list of things to test:

- [ ] Here is testing an invalid request `curl -X PATCH 'http://dev:api_key@localhost:3000/scim/v2/Users/819216' -d '{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op":"Add","path":"displayName","value":"Norris, Chuck"}]}' -H 'Content-Type: application/scim+json'`
- [ ] A valid request should still work as expected `curl -X PATCH 'http://dev:api_key@localhost:3000/scim/v2/Users/819216' -d '{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op":"replace,"value":{"active":true}]}' -H 'Content-Type: application/scim+json'`

To test this, I pointed a locally running lessonly app at the gem (locally) using the bundler path directive. Let me know and we can pair on testing because that requires some set up that I'd be glad to help with!


## Merge Instructions

Please rebase my commits when merging
