### PR TITLE
Upgrade jwt dependency

### DIFF
--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "~> 2.4"
   s.add_dependency "rails", ">= 5.0", "< 6.1"
-  s.add_runtime_dependency "jwt", "~> 1.5.1"
+  s.add_runtime_dependency "jwt", "~> 2.2"
   s.test_files = Dir["spec/**/*"]
 
   s.add_development_dependency "bundler", "~> 2.0"

--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "~> 2.4"
   s.add_dependency "rails", ">= 5.0", "< 6.1"
-  s.add_runtime_dependency "jwt", "~> 2.2"
+  s.add_runtime_dependency "jwt", ">= 1.5"
   s.test_files = Dir["spec/**/*"]
 
   s.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
This upgrades the jwt gem to the latest because jwt version 1.5.x is over four years old.
