### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming Release
 
+# v0.4.0 26-03-2021
+
+- [Rail 6.1 is now supported](https://github.com/lessonly/scim_rails/pull/41)
+
 # v0.3.1 8-06-2020
 
 - [Any unhandled error is now logged](https://github.com/lessonly/scim_rails/pull/27

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
## Why?

This PR handles bumping the version of the gem to v0.4.0. I think the only noteworthy thing here is rails 6.1 support, but if there's anything else then I'm happy to make note of it!

## Merge Instructions

Please **DO NOT** squash my commits when merging
