### PR TITLE
Add list of maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,5 +300,15 @@ Specs can be run with `rspec` at the top level of the project (if you run `rspec
 
 All specs should be passing. (The dummy app will need to be setup first.)
 
+## Current Maintainers
+
+Maintainers:
+- Are active contributors
+- Help set project direction
+- Merge contributions from contributors
+
+- [@wernull](https://github.com/wernull)
+- [@rreinhardt9](https://github.com/rreinhardt9)
+
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
## Why?

We wanted to give more clarity to potential contributors who the current maintainers where since the project itself is just under the "Lessonly" team account. 

## What?

Add a list of maintainers to add clarity on who they are and what they do on this project.

## Testing Notes

N/A
