### PR TITLE
Audit logging

### DIFF
--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -5,8 +5,13 @@ module ScimRails
     include Response
 
     before_action :authorize_request
+    before_action :log_request, if: -> { ScimRails.config.audit_logger }
 
     private
+
+    def log_request
+      ScimRails.config.audit_logger.info request
+    end
 
     def authorize_request
       send(authentication_strategy) do |searchable_attribute, authentication_attribute|

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -40,6 +40,10 @@ ScimRails.configure do |config|
   # For example, [:created_at, :id] or { created_at: :desc }.
   # config.scim_users_list_order = :id
 
+  # This logger will be used to log every incoming SCIM request
+  # using its `info` method. Customize this for audit purposes if needed.
+  # config.audit_logger = Logger.new
+
   # Method called on user model to deprovision a user.
   config.user_deprovision_method = :archive!
 

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -16,6 +16,7 @@ module ScimRails
     ALGO_NONE = "none"
 
     attr_writer \
+      :audit_logger,
       :basic_auth_model,
       :mutable_user_attributes_schema,
       :scim_users_model
@@ -55,6 +56,13 @@ module ScimRails
 
     def scim_users_model
       @scim_users_model.constantize
+    end
+
+    def audit_logger
+      case @audit_logger
+      when String then @audit_logger.constantize
+      else @audit_logger
+      end
     end
   end
 end


### PR DESCRIPTION
## Why?

Closes #47 
In an enterprise context having an auditable log of SCIM requests is essential

## What?

* add option to configure request logging
* log every request if logging is configured

## Testing Notes

- [x] works with config.audit_logger unset
- [x] logs request if config.audit_logger is set to a class name string
- [x] logs request if config.audit_logger is set to something that responds to `info`

### Todo

I'm planning to mark this "ready for review" once I add rspec test cases for the changes and fix any lint violations

## Alternatives Considered

Since it just calls `info` with the request object, it isn't particularly useful with actual Logger instances. Maybe requiring some ScimRails specific interface would be better? (Along the lines of the `on_error` config option)