### PR TITLE
Fix the link of Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/lessonly/scim_rails.svg?branch=master)](https://travis-ci.com/lessonly/scim_rails)
+[![Build Status](https://app.travis-ci.com/lessonly/scim_rails.svg?branch=master)](https://app.travis-ci.com/lessonly/scim_rails)
 [![Inline docs](http://inch-ci.org/github/lessonly/scim_rails.svg?branch=master)](http://inch-ci.org/github/lessonly/scim_rails)
 [![Maintainability](https://api.codeclimate.com/v1/badges/ddfb6a891d2f0d1122ae/maintainability)](https://codeclimate.com/github/lessonly/scim_rails/maintainability)
 


### PR DESCRIPTION
## Why?

The link for Travis CI was incorrect.

## What?

Fix the link of Travis CI badge on README.
