### PR TITLE
Updated version dependency. Removed ~ since it causes a Illformed req…

### DIFF
--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.required_ruby_version = "~> 2.4"
-  s.add_dependency "rails", ">= 5.0", "< 6.2"
-  s.add_runtime_dependency "jwt", ">= 1.5"
+  s.required_ruby_version = "> 2.4"
+  s.add_dependency "rails", ">= 5.0", "< 7.2"
+  s.add_runtime_dependency "jwt", "~>= 1.5"
   s.test_files = Dir["spec/**/*"]
 
   s.add_development_dependency "appraisal"


### PR DESCRIPTION
Dependency error on Windows with ruby 3.1.2p20 and rails 7.0.3.1

## Why?

Bundler didn't install the file on Windows. 
## What?

Removed the ~ character in the version fixed the problem.

## Testing Notes

[x] gem build worked
[x] gem install worked

## Merge Instructions

Please **DO NOT** squash my commits when merging
