### PR TITLE
Update gem to work with Rails 7

### DIFF
--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.required_ruby_version = "~> 2.4"
-  s.add_dependency "rails", ">= 5.0", "< 6.2"
+  s.required_ruby_version = ">= 2.4"
+  s.add_dependency "rails", ">= 5.0"
   s.add_runtime_dependency "jwt", ">= 1.5"
   s.test_files = Dir["spec/**/*"]
 


### PR DESCRIPTION
Allow the gem to be used in rails 7 apps by removing the dependency check.