### PR TITLE
fix: operation==replace assertion fixed

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -140,7 +140,7 @@ module ScimRails
     end
 
     def valid_patch_operation?(operation)
-      operation["op"].casecmp("replace") &&
+      operation["op"].casecmp?("replace") &&
         operation["value"] &&
         [true, false].include?(operation["value"]["active"])
     end


### PR DESCRIPTION
## Why?

`operation["op"].casecmp("replace")` will allways return a "truthy" value, so it is useless for checking if the operation param is actually "replace". The `casecpm?` method should be used.

## What?

Just changes `operation["op"].casecmp("replace")` for `operation["op"].casecmp?("replace")`.

## Caveats

None

## Testing Notes

I don't think any specific testing is required.

