### PR TITLE
LIC-334 - add logs 

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -1,6 +1,7 @@
 module ScimRails
   class ScimUsersController < ScimRails::ApplicationController
     def index
+      Rails.logger.warn("ScimRails::ScimUsersController: index: request.original_url #{request.original_url} request.params: #{params.to_json}")
       if params[:filter].present?
         query = ScimRails::ScimQueryParser.new(params[:filter])
 
@@ -27,6 +28,7 @@ module ScimRails
     end
 
     def create
+      Rails.logger.warn("ScimRails::ScimUsersController: create: request.original_url #{request.original_url} request.params: #{params.to_json}")
       if ScimRails.config.scim_user_prevent_update_on_create
         user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_user_params)
       else
@@ -43,11 +45,13 @@ module ScimRails
     end
 
     def show
+      Rails.logger.warn("ScimRails::ScimUsersController: show: request.original_url #{request.original_url} request.params: #{params.to_json}")
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
       json_scim_response(object: user)
     end
 
     def put_update
+      Rails.logger.warn("ScimRails::ScimUsersController: put_update: request.original_url #{request.original_url} request.params: #{params.to_json}")
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
       update_status(user) unless put_active_param.nil?
       user.update!(permitted_user_params)
@@ -57,6 +61,7 @@ module ScimRails
     # TODO: PATCH will only deprovision or reprovision users.
     # This will work just fine for Okta but is not SCIM compliant.
     def patch_update
+      Rails.logger.warn("ScimRails::ScimUsersController: patch_update: request.original_url #{request.original_url} request.params: #{params.to_json}")
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
       update_status(user)
       json_scim_response(object: user)


### PR DESCRIPTION
## Why?

Need a way to see what external data have passed to lessonly through "scim". 

## What?

Add logs to see what data the "Okta" passed to lessonly through "scim". Mainly about [LIC-334](https://seismic.atlassian.net/browse/LIC-334).
And the aiming target is, NewRelic will catch the logs and searchable inside nr-console.

## Testing Notes

Currently no testing for this change. If want to see if the codes works as normal, please follow the README in this repo and run the spec test.

## Merge Instructions

Please **DO NOT** squash my commits when merging


[LIC-334]: https://seismic.atlassian.net/browse/LIC-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ