### PR TITLE
Upgrade rails dependency to 8.X

### DIFF
--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.required_ruby_version = ">= 2.4"
-  s.add_dependency "rails", ">= 6.0", "<= 7.1"
+  s.add_dependency "rails", ">= 6.0", "<= 8.0"
   s.add_runtime_dependency "jwt", ">= 1.5"
   s.test_files = Dir["spec/**/*"]
 


### PR DESCRIPTION
**Why?**

I've updated the Rails dependency to version 8.0. I've been running this version for quite some time in my local and staging environments and haven’t encountered any issues. This update keeps us current with the latest Rails improvements and ensures long-term maintainability.

**What?**

This PR bumps the Rails version to 8.0. No other changes are included.

**Caveats**

None observed so far. Everything seems to work as expected with the updated Rails version.

**Alternatives Considered**

Sticking with the previous Rails version, but it's preferable to stay up-to-date to benefit from performance improvements, bug fixes, and security patches.